### PR TITLE
Enable custom height location - Fixes #15

### DIFF
--- a/src/SimpleVersion.Abstractions/VersionResult.cs
+++ b/src/SimpleVersion.Abstractions/VersionResult.cs
@@ -4,6 +4,8 @@ namespace SimpleVersion
 {
     public class VersionResult
     {
+        public string Version { get; set; } = string.Empty;
+
         public int Major { get; set; } = 0;
 
         public int Minor { get; set; } = 0;

--- a/src/SimpleVersion.Command/Properties/launchSettings.json
+++ b/src/SimpleVersion.Command/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "SimpleVersion.Command": {
+      "commandName": "Project",
+      "workingDirectory": "C:\\Code\\Tfs\\Framework\\Framework.Build"
+    }
+  }
+}

--- a/src/SimpleVersion.Core/Formatters/Semver1Format.cs
+++ b/src/SimpleVersion.Core/Formatters/Semver1Format.cs
@@ -9,9 +9,12 @@ namespace SimpleVersion.Formatters
         {
             var labelParts = new List<string>(info.Label);
 
-            // if no label, add height to meta data
-            if (labelParts.Count != 0)
-                labelParts.Add(result.HeightPadded);
+            if (!info.Version.Contains("*"))
+            {
+                // if we have a label, ensure height is included
+                if (labelParts.Count != 0 && !labelParts.Contains("*"))
+                    labelParts.Add("*");
+            }
 
             // add short sha if required
             if (info.Branches.AddShortShaToNonRelease && labelParts.Count > 0)
@@ -34,7 +37,9 @@ namespace SimpleVersion.Formatters
             }
 
             var label = string.Join("-", labelParts);
-            var format = info.Version;
+            label = label.Replace("*", result.HeightPadded);
+
+            var format = result.Version;
             
             if (!string.IsNullOrWhiteSpace(label))
                 format += $"-{label}";

--- a/src/SimpleVersion.Core/Formatters/Semver2Format.cs
+++ b/src/SimpleVersion.Core/Formatters/Semver2Format.cs
@@ -10,11 +10,18 @@ namespace SimpleVersion.Formatters
             var labelParts = new List<string>(info.Label);
             var metaParts = new List<string>(info.MetaData);
 
-            // if no label, add height to meta data
-            if (labelParts.Count == 0)
-                metaParts.Insert(0, result.Height.ToString());
-            else
-                labelParts.Add(result.Height.ToString());
+            if (!info.Version.Contains("*"))
+            {
+                if (labelParts.Count == 0)
+                {
+                    if (!metaParts.Contains("*"))
+                        metaParts.Add("*");
+                }
+                else if (!labelParts.Contains("*"))
+                {
+                    labelParts.Add("*");
+                }
+            }
 
             // add short sha if required
             if (info.Branches.AddShortShaToNonRelease)
@@ -37,10 +44,12 @@ namespace SimpleVersion.Formatters
             }
 
             var label = string.Join(".", labelParts);
+            label = label.Replace("*", result.Height.ToString());
+
             var meta = string.Join(".", metaParts);
+            meta = meta.Replace("*", result.Height.ToString());
 
-
-            var format = info.Version;
+            var format = result.Version;
 
             if (!string.IsNullOrWhiteSpace(label))
                 format += $"-{label}";

--- a/src/SimpleVersion.Core/Formatters/VersionFormat.cs
+++ b/src/SimpleVersion.Core/Formatters/VersionFormat.cs
@@ -1,26 +1,24 @@
 ﻿using System;
-using System.Text.RegularExpressions;
 
 namespace SimpleVersion.Formatters
 {
     public class VersionFormat : IVersionFormat
     {
-        private static readonly Regex _regex = new Regex(@"^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:$|\.(?<revision>\d+)$)", RegexOptions.Compiled);
-
         public void Apply(VersionInfo info, VersionResult result)
         {
-            var match = _regex.Match(info.Version);
-            if (match.Success)
+            var versionString = info.Version;
+            if (versionString.Contains("*"))
+                versionString = versionString.Replace("*", result.Height.ToString());
+
+            if (Version.TryParse(versionString, out var version))
             {
-                result.Major = int.Parse(match.Groups["major"].Value);
-                result.Minor = int.Parse(match.Groups["minor"].Value);
-                result.Patch = int.Parse(match.Groups["patch"].Value);
-                var revisionGroup = match.Groups["revision"];
-                if (revisionGroup.Success)
-                    result.Revision = int.Parse(revisionGroup.Value);
-                else
-                    result.Revision = 0;
-            } else
+                result.Version = version.ToString();
+                result.Major = version.Major;
+                result.Minor = version.Minor;
+                result.Patch = version.Build > -1 ? version.Build : 0;
+                result.Revision = version.Revision > -1 ? version.Revision : 0;
+            }
+            else
             {
                 throw new InvalidOperationException($"Version '{info.Version}' is not in a valid format");
             }

--- a/src/SimpleVersion.Core/VersionCalculator.cs
+++ b/src/SimpleVersion.Core/VersionCalculator.cs
@@ -1,0 +1,28 @@
+﻿using SimpleVersion.Git;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleVersion
+{
+    public class VersionCalculator
+    {
+        private readonly GitRepository _repo;
+
+        public VersionCalculator(string path)
+        {
+            _repo = new GitRepository(new JsonVersionInfoReader(), path);
+        }
+
+        public VersionResult Calculate()
+        {
+            var info = _repo.GetResult();
+
+
+
+            return new VersionResult();
+        }
+    }
+}

--- a/test/SimpleVersion.Core.Tests/Formatters/Semver1FormatFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Formatters/Semver1FormatFixture.cs
@@ -20,6 +20,8 @@ namespace SimpleVersion.Core.Tests.Formatters
             yield return new object[] { Array.Empty<object>(), "1.2.0", 10, "1.2.0" };
             yield return new object[] { new[] { "one" }, "1.2.0", 10, "1.2.0-one-0010" };
             yield return new object[] { new[] { "one", "two" } , "1.2.0", 106, "1.2.0-one-two-0106" };
+            yield return new object[] { new[] { "*", "one", "two" } , "1.2.0", 106, "1.2.0-0106-one-two" };
+            yield return new object[] { new[] { "one", "*", "two" } , "1.2.0", 106, "1.2.0-one-0106-two" };
         }
 
         [Theory]
@@ -33,6 +35,7 @@ namespace SimpleVersion.Core.Tests.Formatters
             // Arrange
             var info = Utils.GetVersionInfo(version, label: parts);
             var result = Utils.GetVersionResult(height, false);
+            result.Version = info.Version;
 
             var fullExpected = expectedPart;
 
@@ -62,6 +65,7 @@ namespace SimpleVersion.Core.Tests.Formatters
             // Arrange
             var info = Utils.GetVersionInfo(version, label: parts);
             var result = Utils.GetVersionResult(height, true);
+            result.Version = info.Version;
 
             // Act
             _sut.Apply(info, result);

--- a/test/SimpleVersion.Core.Tests/Formatters/Semver2FormatterFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Formatters/Semver2FormatterFixture.cs
@@ -9,7 +9,7 @@ namespace SimpleVersion.Core.Tests.Formatters
     public class Semver2FormatterFixture
     {
         private readonly Semver2Format _sut;
-        
+
         public Semver2FormatterFixture()
         {
             _sut = new Semver2Format();
@@ -35,8 +35,10 @@ namespace SimpleVersion.Core.Tests.Formatters
             // Arrange
             var info = Utils.GetVersionInfo(version, parts);
             var result = Utils.GetVersionResult(height, false);
+            result.Version = info.Version;
+
             string expected;
-            if(parts.Length > 0)
+            if (parts.Length > 0)
                 expected = $"{version}-{string.Join(".", parts)}.{height}.4ca82d2";
             else
                 expected = $"{version}-4ca82d2+{height}";
@@ -60,6 +62,8 @@ namespace SimpleVersion.Core.Tests.Formatters
             // Arrange
             var info = Utils.GetVersionInfo(version, parts);
             var result = Utils.GetVersionResult(height);
+            result.Version = info.Version;
+
             string expected;
             if (parts.Length > 0)
                 expected = $"{version}-{string.Join(".", parts)}.{height}";
@@ -77,7 +81,7 @@ namespace SimpleVersion.Core.Tests.Formatters
         public static IEnumerable<object[]> MetaDataParts()
         {
             yield return new object[] { Array.Empty<object>(), "1.2.0", 10 };
-            yield return new object[] { new[] { "one" }, "1.2.0", 10};
+            yield return new object[] { new[] { "one" }, "1.2.0", 10 };
             yield return new object[] { new[] { "one", "two" }, "1.2.0", 106 };
         }
 
@@ -91,9 +95,11 @@ namespace SimpleVersion.Core.Tests.Formatters
             // Arrange
             var info = Utils.GetVersionInfo(version, meta: parts);
             var result = Utils.GetVersionResult(height, false);
+            result.Version = info.Version;
+
             string expected;
             if (parts.Length > 0)
-                expected = $"{version}-4ca82d2+{height}.{string.Join(".", parts)}";
+                expected = $"{version}-4ca82d2+{string.Join(".", parts)}.{height}";
             else
                 expected = $"{version}-4ca82d2+{height}";
 
@@ -108,17 +114,19 @@ namespace SimpleVersion.Core.Tests.Formatters
         [Theory]
         [MemberData(nameof(MetaDataParts))]
         public void Apply_MetaDataParts_Release_Is_Formatted(
-            string[] parts, 
-            string version, 
+            string[] parts,
+            string version,
             int height)
         {
 
             // Arrange
             var info = Utils.GetVersionInfo(version, meta: parts);
             var result = Utils.GetVersionResult(height);
+            result.Version = info.Version;
+
             string expected;
             if (parts.Length > 0)
-                expected = $"{version}+{height}.{string.Join(".", parts)}";
+                expected = $"{version}+{string.Join(".", parts)}.{height}";
             else
                 expected = $"{version}+{height}";
 

--- a/test/SimpleVersion.Core.Tests/Formatters/VersionFormatFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Formatters/VersionFormatFixture.cs
@@ -18,7 +18,6 @@ namespace SimpleVersion.Core.Tests.Formatters
         public static IEnumerable<object[]> InvalidVersions()
         {
             yield return new[] { "1" };
-            yield return new[] { "1.2" };
             yield return new[] { "1.2.=" };
             yield return new[] { "1.l.4" };
             yield return new[] { "*.l.5" };
@@ -42,6 +41,7 @@ namespace SimpleVersion.Core.Tests.Formatters
 
         public static IEnumerable<object[]> ValidVersions()
         {
+            yield return new object[] { "1.0", 1, 0, 0, 0 };
             yield return new object[] { "1.0.0", 1, 0, 0, 0 };
             yield return new object[] { "1.2.0", 1, 2, 0, 0 };
             yield return new object[] { "1.2.3", 1, 2, 3, 0 };
@@ -65,6 +65,37 @@ namespace SimpleVersion.Core.Tests.Formatters
             result.Patch.Should().Be(patch);
             result.Revision.Should().Be(revision);
 
+        }
+
+        [Theory]
+        [InlineData("1.0", 10, 1, 0, 0, 0)]
+        [InlineData("1.0.0", 10, 1, 0, 0, 0)]
+        [InlineData("1.0.0.0", 10, 1, 0, 0, 0)]
+        [InlineData("1.*", 10, 1, 10, 0, 0)]
+        [InlineData("1.0.*", 10, 1, 0, 10, 0)]
+        [InlineData("1.0.0.*", 10, 1, 0, 0, 10)]
+        [InlineData("1.*.0", 10, 1, 10, 0, 0)]
+        [InlineData("1.0.*.0", 10, 1, 0, 10, 0)]
+        public void Height_In_Version(
+            string version,
+            int commits,
+            int major,
+            int minor,
+            int patch,
+            int revision)
+        {
+            // Arrange
+            var info = new VersionInfo { Version = version };
+            var result = new VersionResult { Height = commits };
+
+            // Act
+            _sut.Apply(info, result);
+
+            // Assert
+            result.Major.Should().Be(major);
+            result.Minor.Should().Be(minor);
+            result.Patch.Should().Be(patch);
+            result.Revision.Should().Be(revision);
         }
     }
 }

--- a/test/SimpleVersion.Core.Tests/Git/GitRepositoryFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Git/GitRepositoryFixture.cs
@@ -59,9 +59,9 @@ namespace SimpleVersion.Core.Tests.Git
 
                 // write the version file
                 var info = new VersionInfo { Version = "0.1.0" };
-                WriteVersion(info, fixture);
+                Utils.WriteVersion(info, fixture);
 
-                var result = GetResult(sut, fixture);
+                var result = Utils.GetResult(sut, fixture);
 
                 result.Height.Should().Be(1);
             }
@@ -78,14 +78,14 @@ namespace SimpleVersion.Core.Tests.Git
 
                 // write the version file
                 var info = new VersionInfo { Version = "0.1.0" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
 
                 fixture.MakeACommit(); // 2
                 fixture.MakeACommit(); // 3
                 fixture.MakeACommit(); // 4
                 fixture.MakeACommit(); // 5
 
-                var result = GetResult(sut, fixture);
+                var result = Utils.GetResult(sut, fixture);
 
                 result.Height.Should().Be(5);
             }
@@ -101,7 +101,7 @@ namespace SimpleVersion.Core.Tests.Git
 
                 // write the version file
                 var info = new VersionInfo { Version = "0.1.0" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
 
                 fixture.MakeACommit(); // 2
                 fixture.MakeACommit(); // 3
@@ -109,9 +109,9 @@ namespace SimpleVersion.Core.Tests.Git
                 fixture.MakeACommit(); // 5
 
                 info.MetaData.Add("example");
-                WriteVersion(info, fixture); // 6
+                Utils.WriteVersion(info, fixture); // 6
 
-                var result = GetResult(sut, fixture);
+                var result = Utils.GetResult(sut, fixture);
 
                 result.Height.Should().Be(6);
             }
@@ -127,7 +127,7 @@ namespace SimpleVersion.Core.Tests.Git
 
                 // write the version file
                 var info = new VersionInfo { Version = "0.1.0" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
 
                 fixture.MakeACommit(); // 2
                 fixture.MakeACommit(); // 3
@@ -142,7 +142,7 @@ namespace SimpleVersion.Core.Tests.Git
                 fixture.Checkout("master");
                 fixture.MergeNoFF("feature/other"); // 6
 
-                var result = GetResult(sut, fixture);
+                var result = Utils.GetResult(sut, fixture);
 
                 result.Height.Should().Be(6);
             }
@@ -158,7 +158,7 @@ namespace SimpleVersion.Core.Tests.Git
 
                 // write the version file
                 var info = new VersionInfo { Version = "0.1.0" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
 
                 fixture.MakeACommit(); // 2
                 fixture.MakeACommit(); // 3
@@ -168,14 +168,14 @@ namespace SimpleVersion.Core.Tests.Git
                 fixture.BranchTo("feature/other");
                 fixture.MakeACommit(); // feature 1
                 info = new VersionInfo { Version = "0.1.1" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
                 fixture.MakeACommit(); // feature 2
                 fixture.MakeACommit(); // feature 3
 
                 fixture.Checkout("master");
                 fixture.MergeNoFF("feature/other"); // 1
 
-                var result = GetResult(sut, fixture);
+                var result = Utils.GetResult(sut, fixture);
 
                 result.Height.Should().Be(1);
             }
@@ -191,7 +191,7 @@ namespace SimpleVersion.Core.Tests.Git
 
                 // write the version file
                 var info = new VersionInfo { Version = "0.1.0" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
 
                 fixture.MakeACommit(); // 2
                 fixture.MakeACommit(); // 3
@@ -201,7 +201,7 @@ namespace SimpleVersion.Core.Tests.Git
                 fixture.BranchTo("feature/other");
                 fixture.MakeACommit(); // feature 1
                 info = new VersionInfo { Version = "0.1.1" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
                 fixture.MakeACommit(); // feature 2
                 fixture.MakeACommit(); // feature 3
 
@@ -211,34 +211,19 @@ namespace SimpleVersion.Core.Tests.Git
                 fixture.Checkout("feature/other");
                 fixture.MakeACommit(); // feature 1
                 info = new VersionInfo { Version = "0.1.2" };
-                WriteVersion(info, fixture); // 1
+                Utils.WriteVersion(info, fixture); // 1
                 fixture.MakeACommit(); // feature 2
                 fixture.MakeACommit(); // feature 3
 
                 fixture.Checkout("master");
                 fixture.MergeNoFF("feature/other"); // 1
 
-                var result = GetResult(sut, fixture);
+                var result = Utils.GetResult(sut, fixture);
 
                 result.Height.Should().Be(1);
             }
         }
 
-        private void WriteVersion(VersionInfo info, RepositoryFixtureBase fixture)
-        {
-            // write the version file
-            _writer.ToFile(info, fixture.RepositoryPath);
-            fixture.Repository.Index.Add(Constants.VersionFileName);
-            fixture.Repository.Index.Write();
-            fixture.MakeACommit();
-        }
-
-        private VersionResult GetResult(GitRepository sut, RepositoryFixtureBase fixture)
-        {
-            var result = sut.GetResult();
-            fixture.ApplyTag(result.Formats["Semver2"]);
-
-            return result;
-        }
+       
     }
 }

--- a/test/SimpleVersion.Core.Tests/Utils.cs
+++ b/test/SimpleVersion.Core.Tests/Utils.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using GitTools.Testing;
+using SimpleVersion.Git;
+using System;
 using System.Collections.Generic;
 
-namespace SimpleVersion.Core.Tests.Formatters
+namespace SimpleVersion.Core.Tests
 {
     public static class Utils
     {
@@ -37,6 +39,25 @@ namespace SimpleVersion.Core.Tests.Formatters
                 Sha = "4ca82d2c58f48007bf16d69ebf036fc4ebfdd059",
                 Height = height
             };
+        }
+
+        public static void WriteVersion(VersionInfo info, RepositoryFixtureBase fixture, bool commit = true)
+        {
+            // write the version file
+            var writer = new JsonVersionInfoWriter();
+            writer.ToFile(info, fixture.RepositoryPath);
+            fixture.Repository.Index.Add(Constants.VersionFileName);
+            fixture.Repository.Index.Write();
+            if(commit)
+                fixture.MakeACommit();
+        }
+
+        public static VersionResult GetResult(GitRepository sut, RepositoryFixtureBase fixture)
+        {
+            var result = sut.GetResult();
+            fixture.ApplyTag(result.Formats["Semver2"]);
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
`*` can be provided in version, label or metadata
If not provided in version and label exists, adds to label (unless specified in a location)
If not provided in version and no label exists, adds to metadata (unless specified in a location)