### PR TITLE
Initial token rule implementation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -19,8 +19,6 @@ All of the following are accepted values:
 "Version" : "1.2.3.4"
 ```
 
-> You may also specify '*' in place of a number to insert the generated height.
-
 Label
 -----
 
@@ -33,7 +31,6 @@ The `Label` property specifies an array of labels to be included in the version.
 "Label" : ["alpha1"]
 "Label" : ["alpha1", "test"]
 ```
-> You may also specify '*' in place of a value to insert the generated height.
 
 MetaData
 --------
@@ -48,8 +45,6 @@ in the final version.
 "MetaData" : ["demo"]
 "MetaData" : ["demo", "sprint1"]
 ```
-
-> You may also specify '*' in place of a value to insert the generated height.
 
 OffSet
 ------
@@ -99,3 +94,16 @@ Semver2 verison of `0.1.0-alpha2.5` when there are five commits.
 All other branches will append the short sha, generating a Semver2 version of
 `0.1.0-alpha2.5.c903782` when there are five commits and the sha begins with
 _903782_
+
+Replacement Tokens
+------------------
+
+SimpleVersion allows specific _tokens_ to be used in some properties to allow
+substitution of values during invocation.  The following tokens may be used:
+
+
+| Name        | Token          | Where                          | Description                                                             |
+| ----------- | -------------- | ------------------------------ | ----------------------------------------------------------------------- |
+| Height      | `*`            | `Version`, `Label`, `Metadata` | Inserts the calcualted height                                           |
+| Branch Name | `{branchname}` | `Label`, `Metadata`            | Inserts the branch name, stripped of non-alphanumeric characters        |
+| Short Sha   | `{shortsha}`   | `Label`, `Metadata`            | Inserts the first seven characters of the commit sha, prefixed with `c` |

--- a/src/SimpleVersion.Abstractions/Rules/IRule.cs
+++ b/src/SimpleVersion.Abstractions/Rules/IRule.cs
@@ -1,0 +1,14 @@
+﻿using SimpleVersion.Pipeline;
+using System.Collections.Generic;
+
+namespace SimpleVersion.Rules
+{
+    public interface IRule<T>
+    {
+        string Token { get; }
+
+        T Resolve(VersionContext context, T value);
+
+        IEnumerable<T> Apply(VersionContext context, IEnumerable<T> value);
+    }
+}

--- a/src/SimpleVersion.Core/Pipeline/Formatting/Semver2FormatProcess.cs
+++ b/src/SimpleVersion.Core/Pipeline/Formatting/Semver2FormatProcess.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text.RegularExpressions;
+﻿using SimpleVersion.Rules;
 
 namespace SimpleVersion.Pipeline.Formatting
 {
@@ -7,39 +6,17 @@ namespace SimpleVersion.Pipeline.Formatting
     {
         public void Apply(VersionContext context)
         {
-            var labelParts = new List<string>(context.Configuration.Label);
-            var metaParts = new List<string>(context.Configuration.MetaData);
-
-            if (!context.Configuration.Version.Contains("*"))
+            var rules = new IRule<string>[]
             {
-                // if we have a label, ensure height is included
-                if (labelParts.Count != 0 && !labelParts.Contains("*"))
-                    labelParts.Add("*");
-            }
+                HeightRule.Instance,
+                ShortShaRule.Instance,
+                BranchNameRule.Instance
+            };
 
-            // add short sha if required
-            var addShortSha = true;
-            foreach (var pattern in context.Configuration.Branches.Release)
-            {
-                if (Regex.IsMatch(context.Result.CanonicalBranchName, pattern))
-                {
-                    addShortSha = false;
-                    break;
-                }
-            }
-
-            if (addShortSha)
-            {
-                var shortSha = context.Result.Sha.Substring(0, 7);
-                labelParts.Add($"c{shortSha}");
-            }
-
-            var label = string.Join(".", labelParts);
-            label = label.Replace("*", context.Result.Height.ToString());
-
-            var meta = string.Join(".", metaParts);
-            meta = meta.Replace("*", context.Result.Height.ToString());
-
+            var labelParts = context.Configuration.Label.ApplyRules(context, rules);
+            var label = string.Join(".", labelParts).ResolveRules(context, rules);
+            var meta = string.Join(".", context.Configuration.MetaData).ResolveRules(context, rules);
+            
             var format = context.Result.Version;
 
             if (!string.IsNullOrWhiteSpace(label))

--- a/src/SimpleVersion.Core/Pipeline/Formatting/VersionFormatProcess.cs
+++ b/src/SimpleVersion.Core/Pipeline/Formatting/VersionFormatProcess.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SimpleVersion.Rules;
+using System;
 
 namespace SimpleVersion.Pipeline.Formatting
 {
@@ -6,9 +7,7 @@ namespace SimpleVersion.Pipeline.Formatting
     {
         public void Apply(VersionContext context)
         {
-            var versionString = context.Configuration.Version;
-            if (versionString.Contains("*"))
-                versionString = versionString.Replace("*", context.Result.Height.ToString());
+            var versionString = HeightRule.Instance.Resolve(context, context.Configuration.Version);
 
             if (Version.TryParse(versionString, out var version))
             {

--- a/src/SimpleVersion.Core/Rules/BranchNameRule.cs
+++ b/src/SimpleVersion.Core/Rules/BranchNameRule.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using SimpleVersion.Pipeline;
+
+namespace SimpleVersion.Rules
+{
+    public class BranchNameRule : IRule<string>
+    {
+        private static Lazy<BranchNameRule> _default = new Lazy<BranchNameRule>(() => new BranchNameRule());
+        private static string _defaultPattern = "[^a-z0-9]";
+
+        public static BranchNameRule Instance => _default.Value;
+
+        public string Token => "{branchname}";
+
+        public BranchNameRule(): this(_defaultPattern, false)
+        {
+
+        }
+
+        public BranchNameRule(bool useCanonical) : this(_defaultPattern, useCanonical)
+        {
+        }
+
+        public BranchNameRule(string pattern, bool useCanonical)
+        {
+            Pattern = new Regex(pattern, RegexOptions.IgnoreCase);
+            UseCanonical = useCanonical;
+        }
+
+        public Regex Pattern { get; }
+
+        public bool UseCanonical { get; }
+
+        public IEnumerable<string> Apply(VersionContext context, IEnumerable<string> value)
+        {
+            // No default implementation applies branch name
+            return value;
+        }
+
+        public string Resolve(VersionContext context, string value)
+        {
+            var name = UseCanonical ? context.Result.CanonicalBranchName : context.Result.BranchName;
+            name = Pattern.Replace(name, "");
+            return Regex.Replace(value, Regex.Escape(Token), name, RegexOptions.IgnoreCase);
+        }
+    }
+}

--- a/src/SimpleVersion.Core/Rules/HeightRule.cs
+++ b/src/SimpleVersion.Core/Rules/HeightRule.cs
@@ -1,0 +1,48 @@
+﻿using SimpleVersion.Pipeline;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SimpleVersion.Rules
+{
+    public class HeightRule : IRule<string>
+    {
+        private static Lazy<HeightRule> _default = new Lazy<HeightRule>(() => new HeightRule());
+
+        public static HeightRule Instance => _default.Value;
+
+        public HeightRule() :this(false)
+        {
+            
+        }
+
+        public HeightRule(bool padded)
+        {
+            Padded = padded;
+        }
+
+        public bool Padded { get; }
+
+        public string Token => "*";
+
+        public string Resolve(VersionContext context, string value)
+        {
+            if (Padded)
+                return value.Replace(Token, context.Result.HeightPadded);
+            else
+                return value.Replace(Token, context.Result.Height.ToString());
+        }
+
+        public IEnumerable<string> Apply(VersionContext context, IEnumerable<string> input)
+        {
+            if (!context.Configuration.Version.Contains(Token)
+                && input.Count() != 0
+                && !input.Contains(Token))
+            {
+                return input.Concat(new[] { Token });
+            }
+
+            return input;
+        }
+    }
+}

--- a/src/SimpleVersion.Core/Rules/RuleExtensions.cs
+++ b/src/SimpleVersion.Core/Rules/RuleExtensions.cs
@@ -1,0 +1,26 @@
+﻿using SimpleVersion.Pipeline;
+using System.Collections.Generic;
+
+namespace SimpleVersion.Rules
+{
+    public static class RuleExtensions
+    {
+        public static IEnumerable<T> ApplyRules<T>(this IEnumerable<T> value, VersionContext context, IEnumerable<IRule<T>> rules)
+        {
+            var next = value;
+            foreach (var rule in rules)
+                next = rule.Apply(context, next);
+
+            return next;
+        }
+
+        public static T ResolveRules<T>(this T value, VersionContext context, IEnumerable<IRule<T>> rules)
+        {
+            var next = value;
+            foreach (var rule in rules)
+                next = rule.Resolve(context, next);
+
+            return next;
+        }
+    }
+}

--- a/src/SimpleVersion.Core/Rules/ShortShaRule.cs
+++ b/src/SimpleVersion.Core/Rules/ShortShaRule.cs
@@ -25,7 +25,7 @@ namespace SimpleVersion.Rules
             var isRelease = context.Configuration.Branches.Release
                 .Any(x => Regex.IsMatch(context.Result.CanonicalBranchName, x));
 
-            if (!isRelease)
+            if (!isRelease && !input.Contains(Token))
             {
                 return input.Concat(new[] { Token });
             }

--- a/src/SimpleVersion.Core/Rules/ShortShaRule.cs
+++ b/src/SimpleVersion.Core/Rules/ShortShaRule.cs
@@ -1,0 +1,36 @@
+﻿using SimpleVersion.Pipeline;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SimpleVersion.Rules
+{
+    public class ShortShaRule : IRule<string>
+    {
+        private static Lazy<ShortShaRule> _default = new Lazy<ShortShaRule>(() => new ShortShaRule());
+
+        public static ShortShaRule Instance => _default.Value;
+
+        public string Token => "{shortsha}";
+
+        public string Resolve(VersionContext context, string value)
+        {
+            var shortSha = context.Result.Sha.Substring(0, 7);
+            return Regex.Replace(value, Regex.Escape(Token), $"c{shortSha}", RegexOptions.IgnoreCase);
+        }
+
+        public IEnumerable<string> Apply(VersionContext context, IEnumerable<string> input)
+        {
+            var isRelease = context.Configuration.Branches.Release
+                .Any(x => Regex.IsMatch(context.Result.CanonicalBranchName, x));
+
+            if (!isRelease)
+            {
+                return input.Concat(new[] { Token });
+            }
+
+            return input;
+        }
+    }
+}

--- a/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver1FormatProcessFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver1FormatProcessFixture.cs
@@ -41,14 +41,9 @@ namespace SimpleVersion.Core.Tests.Pipeline.Formatting
             };
             context.Result.Version = context.Configuration.Version;
 
-            var fullExpected = expectedPart;
-
-            if (parts.Length > 0)
-            {
-                var shaSub = context.Result.Sha.Substring(0, 7);
-                fullExpected = $"{expectedPart}-c{shaSub}";
-            }
-
+            var shaSub = context.Result.Sha.Substring(0, 7);
+            var fullExpected = $"{expectedPart}-c{shaSub}";
+            
             // Act
             _sut.Apply(context);
 

--- a/test/SimpleVersion.Core.Tests/Rules/BranchNameRuleFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Rules/BranchNameRuleFixture.cs
@@ -1,0 +1,116 @@
+﻿using FluentAssertions;
+using SimpleVersion.Pipeline;
+using SimpleVersion.Rules;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SimpleVersion.Core.Tests.Rules
+{
+    public class BranchNameRuleFixture
+    {
+        [Fact]
+        public void Instance_SetsDefaults()
+        {
+            // Arrange / Act
+            var sut = BranchNameRule.Instance;
+
+            // Assert
+            sut.Pattern.Should().NotBeNull();
+            sut.UseCanonical.Should().BeFalse();
+        }
+
+        public static IEnumerable<object[]> ApplyData()
+        {
+            yield return new object[] { null, null };
+            yield return new object[] { null, Array.Empty<string>() };
+            yield return new object[] { new VersionContext(), new[] { "this" } };
+        }
+
+        [Theory]
+        [MemberData(nameof(ApplyData))]
+        public void Apply_Returns_Input(VersionContext context, IEnumerable<string> input)
+        {
+            // Arrange
+            var sut = new BranchNameRule();
+
+            // Act
+            var result = sut.Apply(context, input);
+
+            // Assert
+            result.Should().BeSameAs(input);
+        }
+
+        [Theory]
+        [InlineData("master", "{branchName}", "master")]
+        [InlineData("master", "{BRANCHNAME}", "master")]
+        [InlineData("release/1.0", "{BRANCHNAME}", "release10")]
+        [InlineData("release-1.0", "{BRANCHNAME}", "release10")]
+        public void Resolve_Replaces_BranchName(string branchName, string input, string expected)
+        {
+            // Arrange
+            var sut = new BranchNameRule();
+            var context = new VersionContext
+            {
+                Result =
+                {
+                    BranchName = branchName
+                }
+            };
+
+            // Act
+            var result = sut.Resolve(context, input);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("refs/heads/master", "{branchName}", "refsheadsmaster")]
+        [InlineData("refs/heads/master", "{BRANCHNAME}", "refsheadsmaster")]
+        [InlineData("refs/heads/release/1.0", "{BRANCHNAME}", "refsheadsrelease10")]
+        [InlineData("refs/heads/release-1.0", "{BRANCHNAME}", "refsheadsrelease10")]
+        public void Resolve_Replaces_CanonicalBranchName(string branchName, string input, string expected)
+        {
+            // Arrange
+            var sut = new BranchNameRule(true);
+            var context = new VersionContext
+            {
+                Result =
+                {
+                    CanonicalBranchName = branchName
+                }
+            };
+
+            // Act
+            var result = sut.Resolve(context, input);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("master", "{branchName}", "[mr]", "aste")]
+        public void Resolve_CustomPattern_Replaces_BranchName(string branchName, string input, string pattern, string expected)
+        {
+            // Arrange
+            var sut = new BranchNameRule(pattern, false);
+            var context = new VersionContext
+            {
+                Result =
+                {
+                    BranchName = branchName
+                }
+            };
+
+            // Act
+            var result = sut.Resolve(context, input);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/test/SimpleVersion.Core.Tests/Rules/HeightRuleFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Rules/HeightRuleFixture.cs
@@ -1,0 +1,118 @@
+﻿using FluentAssertions;
+using SimpleVersion.Pipeline;
+using SimpleVersion.Rules;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace SimpleVersion.Core.Tests.Rules
+{
+    public class HeightRuleFixture
+    {
+        [Fact]
+        public void Instance_Padded_IsFalse()
+        {
+            // Arrange
+            var sut = HeightRule.Instance;
+
+            // Act
+            var result = sut.Padded;
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Token_Is_Asterisk()
+        {
+            // Arrange / Act
+            var sut = new HeightRule();
+
+            // Assert
+            sut.Token.Should().Be("*");
+        }
+
+        [Fact]
+        public void Padded_ByDefault_IsFalse()
+        {
+            // Arrange / Act
+            var sut = new HeightRule();
+
+            // Assert
+            sut.Padded.Should().BeFalse();
+        }
+
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Padded_WhenSet_SetsCorrectly(bool usePadding)
+        {
+            // Arrange / Act
+            var sut = new HeightRule(usePadding);
+
+            // Assert
+            sut.Padded.Should().Be(usePadding);
+        }
+
+        [Theory]
+        [InlineData(true, 10, "myString-*", "myString-0010")]
+        [InlineData(false, 15, "myString-*", "myString-15")]
+        [InlineData(true, 10, "myString-*.*", "myString-0010.0010")]
+        [InlineData(false, 15, "myString-*-*", "myString-15-15")]
+        [InlineData(true, 10, "myString", "myString")]
+        [InlineData(false, 15, "myString", "myString")]
+        public void Resolve_ReplacesToken_IfNeeded(bool usePadding, int height, string input, string expected)
+        {
+            // Arrange
+            var sut = new HeightRule(usePadding);
+            var context = new VersionContext
+            {
+                Result =
+                {
+                    Height = height
+                }
+            };
+
+            // Act
+            var result = sut.Resolve(context, input);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        public static IEnumerable<object[]> ApplyData()
+        {
+            // Version in string, Do not add to label
+            yield return new object[] { "1.*", new[] { "this" }, new[] { "this" } };
+            // No release label, Do not add to label
+            yield return new object[] { "1.0", Array.Empty<string>(), Array.Empty<string>() };
+            // Not in version and release, append to end
+            yield return new object[] { "1.0", new[] { "this" }, new[] { "this", "*" } };
+        }
+
+
+        [Theory]
+        [MemberData(nameof(ApplyData))]
+        public void Apply_Appends_IfRequired(string version, IEnumerable<string> input, IEnumerable<string> expected)
+        {
+            // Arrange
+            var sut = new HeightRule();
+            var context = new VersionContext
+            {
+                Configuration =
+                {
+                    Version = version
+                }
+            };
+
+            // Act
+            var result = sut.Apply(context, input);
+
+            // Assert
+            result.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
+        }
+
+    }
+}

--- a/test/SimpleVersion.Core.Tests/Rules/ShortShaRuleFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Rules/ShortShaRuleFixture.cs
@@ -1,0 +1,74 @@
+﻿using FluentAssertions;
+using SimpleVersion.Pipeline;
+using SimpleVersion.Rules;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace SimpleVersion.Core.Tests.Rules
+{
+    public class ShortShaRuleFixture
+    {
+        private ShortShaRule _sut;
+
+        public ShortShaRuleFixture()
+        {
+            _sut = new ShortShaRule();
+        }
+
+        [Fact]
+        public void Token_Is_Correct()
+        {
+            // Act / Assert
+            _sut.Token.Should().Be("{shortsha}");
+        }
+
+        [Theory]
+        [InlineData("{shortSha}", "c4ca82d2")]
+        [InlineData("{SHORTSHA}", "c4ca82d2")]
+        [InlineData("this-{shortsha}", "this-c4ca82d2")]
+        [InlineData("this", "this")]
+        public void Resolve_ReplacesToken_IfNeeded(string input, string expected)
+        {
+            // Arrange
+            var context = new VersionContext
+            {
+                Result = Utils.GetVersionResult(10)
+            };
+
+            // Act
+            var result = _sut.Resolve(context, input);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        public static IEnumerable<object[]> ApplyData()
+        {
+            // release branch does not include sha
+            yield return new object[] { true, new[] { "this" }, new[] { "this" } };
+            // non-release sha appends
+            yield return new object[] { false, new[] { "this" }, new[] { "this", "{shortsha}" } };
+            // empty array appends
+            yield return new object[] { false, Array.Empty<string>(), new[] { "{shortsha}" } };
+        }
+
+        [Theory]
+        [MemberData(nameof(ApplyData))]
+        public void Apply_AppendsToken_IfNeeded(bool isRelease, IEnumerable<string> input, IEnumerable<string> expected)
+        {
+            // Arrange
+            var context = new VersionContext
+            {
+                Configuration = Utils.GetConfiguration("1.2.3"),
+                Result = Utils.GetVersionResult(10, isRelease)
+            };
+
+            // Act
+            var result = _sut.Apply(context, input);
+
+            // Assert
+            result.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
+        }
+    }
+}

--- a/test/SimpleVersion.Core.Tests/Rules/ShortShaRuleFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Rules/ShortShaRuleFixture.cs
@@ -49,6 +49,8 @@ namespace SimpleVersion.Core.Tests.Rules
             yield return new object[] { true, new[] { "this" }, new[] { "this" } };
             // non-release sha appends
             yield return new object[] { false, new[] { "this" }, new[] { "this", "{shortsha}" } };
+            // non-release sha does not append if already there
+            yield return new object[] { false, new[] { "{shortsha}", "this" }, new[] { "{shortsha}", "this" } };
             // empty array appends
             yield return new object[] { false, Array.Empty<string>(), new[] { "{shortsha}" } };
         }


### PR DESCRIPTION
Implements a pattern for tokens to be included.  Allowing definition and application of rules to replace tokens with variables in result values.
This first pass allows `{branchname}`, `{shortsha}` and `*` to be used.