### PR TITLE
Fix #55 - Implement branchnamesuffix

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -102,9 +102,10 @@ SimpleVersion allows specific _tokens_ to be used in some properties to allow
 substitution of values during invocation.  The following tokens may be used:
 
 
-| Name              | Token               | Where                          | Description                                                                |
-| ----------------- | ------------------- | ------------------------------ | -------------------------------------------------------------------------- |
-| Height            | `*`                 | `Version`, `Label`, `Metadata` | Inserts the calculated height                                              |
-| Branch Name       | `{branchname}`      | `Label`, `Metadata`            | Inserts the canonical branch name, stripped of non-alphanumeric characters |
-| Short Branch Name | `{shortbranchname}` | `Label`, `Metadata`            | Inserts the friendly branch name, stripped of non-alphanumeric characters  |
-| Short Sha         | `{shortsha}`        | `Label`, `Metadata`            | Inserts the first seven characters of the commit sha, prefixed with `c`    |
+| Name               | Token                | Where                          | Description                                                                |
+| ------------------ | -------------------- | ------------------------------ | -------------------------------------------------------------------------- |
+| Height             | `*`                  | `Version`, `Label`, `Metadata` | Inserts the calculated height                                              |
+| Branch Name        | `{branchname}`       | `Label`, `Metadata`            | Inserts the canonical branch name, stripped of non-alphanumeric characters |
+| Short Branch Name  | `{shortbranchname}`  | `Label`, `Metadata`            | Inserts the friendly branch name, stripped of non-alphanumeric characters  |
+| Branch Name Suffix | `{branchnamesuffix}` | `Label`, `Metadata`            | Inserts the last segment of the canonical name of a branch				  |
+| Short Sha          | `{shortsha}`         | `Label`, `Metadata`            | Inserts the first seven characters of the commit sha, prefixed with `c`    |

--- a/docs/Results.md
+++ b/docs/Results.md
@@ -16,6 +16,7 @@ The following is an example from invoking the command line tool:
   "Height": 18,
   "HeightPadded": "0018",
   "Sha": "ebc8f22ae83bfa3c1e36d6bf70c2a383ae30c9dd",
+  "CanonicalBranchName": "refs/heads/preview/test",
   "BranchName": "preview/test",
   "Formats": {
     "Semver1": "0.1.0-alpha2-0018",

--- a/src/SimpleVersion.Core/Pipeline/Formatting/Semver1FormatProcess.cs
+++ b/src/SimpleVersion.Core/Pipeline/Formatting/Semver1FormatProcess.cs
@@ -11,7 +11,8 @@ namespace SimpleVersion.Pipeline.Formatting
                 new HeightRule(true),
                 ShortShaRule.Instance,
                 BranchNameRule.Instance,
-                ShortBranchNameRule.Instance
+                ShortBranchNameRule.Instance,
+                BranchNameSuffixRule.Instance
             };
 
             var labelParts = context.Configuration.Label.ApplyRules(context, rules);

--- a/src/SimpleVersion.Core/Pipeline/Formatting/Semver2FormatProcess.cs
+++ b/src/SimpleVersion.Core/Pipeline/Formatting/Semver2FormatProcess.cs
@@ -11,7 +11,8 @@ namespace SimpleVersion.Pipeline.Formatting
                 HeightRule.Instance,
                 ShortShaRule.Instance,
                 BranchNameRule.Instance,
-                ShortBranchNameRule.Instance
+                ShortBranchNameRule.Instance,
+                BranchNameSuffixRule.Instance
             };
 
             var labelParts = context.Configuration.Label.ApplyRules(context, rules);

--- a/src/SimpleVersion.Core/Rules/BaseBranchNameRule.cs
+++ b/src/SimpleVersion.Core/Rules/BaseBranchNameRule.cs
@@ -13,22 +13,19 @@ namespace SimpleVersion.Rules
         protected static string _defaultPattern = "[^a-z0-9]";
 
 
-        protected BaseBranchNameRule(bool useCanonical) : this(_defaultPattern, useCanonical)
+        protected BaseBranchNameRule() : this(_defaultPattern)
         {
         }
 
-        protected BaseBranchNameRule(string pattern, bool useCanonical)
+        protected BaseBranchNameRule(string pattern)
         {
             Pattern = new Regex(pattern, RegexOptions.IgnoreCase);
-            UseCanonical = useCanonical;
         }
 
         public abstract string Token { get; protected set; }
 
         public Regex Pattern { get; protected set; }
-
-        public bool UseCanonical { get; protected set; }
-
+        
         public virtual IEnumerable<string> Apply(VersionContext context, IEnumerable<string> value)
         {
             // No default implementation applies branch name
@@ -37,14 +34,16 @@ namespace SimpleVersion.Rules
 
         public virtual string Resolve(VersionContext context, string value)
         {
-            var name = ResolveBranchName(context);
-            name = Pattern.Replace(name, "");
-            return Regex.Replace(value, Regex.Escape(Token), name, RegexOptions.IgnoreCase);
+            if (Regex.IsMatch(value, Token, RegexOptions.IgnoreCase))
+            {
+                var name = ResolveBranchName(context);
+                name = Pattern.Replace(name, "");
+                return Regex.Replace(value, Regex.Escape(Token), name, RegexOptions.IgnoreCase);
+            }
+
+            return value;
         }
 
-        protected virtual string ResolveBranchName(VersionContext context)
-        {
-            return UseCanonical ? context.Result.CanonicalBranchName : context.Result.BranchName;
-        }
+        protected abstract string ResolveBranchName(VersionContext context);
     }
 }

--- a/src/SimpleVersion.Core/Rules/BranchNameRule.cs
+++ b/src/SimpleVersion.Core/Rules/BranchNameRule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SimpleVersion.Pipeline;
 
 namespace SimpleVersion.Rules
 {
@@ -8,14 +9,16 @@ namespace SimpleVersion.Rules
 
         public static BranchNameRule Instance => _default.Value;
 
-        public BranchNameRule() : base(true)
+        public BranchNameRule() : base()
         {
         }
 
-        public BranchNameRule(string pattern) : base(pattern, true)
+        public BranchNameRule(string pattern) : base(pattern)
         {
         }                
 
         public override string Token { get; protected set; } = "{branchname}";
+
+        protected override string ResolveBranchName(VersionContext context) => context.Result.CanonicalBranchName;
     }
 }

--- a/src/SimpleVersion.Core/Rules/BranchNameSuffixRule.cs
+++ b/src/SimpleVersion.Core/Rules/BranchNameSuffixRule.cs
@@ -1,0 +1,27 @@
+﻿using SimpleVersion.Pipeline;
+using System;
+
+namespace SimpleVersion.Rules
+{
+    public class BranchNameSuffixRule : BaseBranchNameRule
+    {
+        private static Lazy<BranchNameSuffixRule> _default = new Lazy<BranchNameSuffixRule>(() => new BranchNameSuffixRule());
+
+        public static BranchNameSuffixRule Instance => _default.Value;
+
+        public BranchNameSuffixRule() : base()
+        {
+        }
+
+        public BranchNameSuffixRule(string pattern) : base(pattern)
+        {
+        }
+        
+        public override string Token { get; protected set; } = "{branchnamesuffix}";
+
+        protected override string ResolveBranchName(VersionContext context)
+        {
+            return context.Result.CanonicalBranchName.Substring(context.Result.CanonicalBranchName.LastIndexOf('/') + 1);
+        }
+    }
+}

--- a/src/SimpleVersion.Core/Rules/ShortBranchNameRule.cs
+++ b/src/SimpleVersion.Core/Rules/ShortBranchNameRule.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SimpleVersion.Pipeline;
+using System;
 
 namespace SimpleVersion.Rules
 {
@@ -8,14 +9,16 @@ namespace SimpleVersion.Rules
 
         public static ShortBranchNameRule Instance => _default.Value;
 
-        public ShortBranchNameRule() : base(false)
+        public ShortBranchNameRule() : base()
         {
         }
 
-        public ShortBranchNameRule(string pattern) : base(pattern, false)
+        public ShortBranchNameRule(string pattern) : base(pattern)
         {
         }
         
         public override string Token { get; protected set; } = "{shortbranchname}";
+
+        protected override string ResolveBranchName(VersionContext context) => context.Result.BranchName;
     }
 }

--- a/test/SimpleVersion.Core.Tests/Rules/BranchNameRuleFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Rules/BranchNameRuleFixture.cs
@@ -17,7 +17,7 @@ namespace SimpleVersion.Core.Tests.Rules
 
             // Assert
             sut.Pattern.Should().NotBeNull();
-            sut.UseCanonical.Should().BeTrue();
+            sut.Token.Should().Be("{branchname}");
         }
 
         public static IEnumerable<object[]> ApplyData()

--- a/test/SimpleVersion.Core.Tests/Rules/BranchNameSuffixRuleFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Rules/BranchNameSuffixRuleFixture.cs
@@ -7,17 +7,17 @@ using Xunit;
 
 namespace SimpleVersion.Core.Tests.Rules
 {
-    public class ShortBranchNameRuleFixture
+    public class BranchNameSuffixRuleFixture
     {
         [Fact]
         public void Instance_SetsDefaults()
         {
             // Arrange / Act
-            var sut = ShortBranchNameRule.Instance;
+            var sut = BranchNameSuffixRule.Instance;
 
             // Assert
             sut.Pattern.Should().NotBeNull();
-            sut.Token.Should().Be("{shortbranchname}");
+            sut.Token.Should().Be("{branchnamesuffix}");
         }
 
         public static IEnumerable<object[]> ApplyData()
@@ -32,7 +32,7 @@ namespace SimpleVersion.Core.Tests.Rules
         public void Apply_Returns_Input(VersionContext context, IEnumerable<string> input)
         {
             // Arrange
-            var sut = new ShortBranchNameRule();
+            var sut = new BranchNameSuffixRule();
 
             // Act
             var result = sut.Apply(context, input);
@@ -42,19 +42,19 @@ namespace SimpleVersion.Core.Tests.Rules
         }
 
         [Theory]
-        [InlineData("master", "{shortBranchName}", "master")]
-        [InlineData("master", "{SHORTBRANCHNAME}", "master")]
-        [InlineData("release/1.0", "{shortBRANCHNAME}", "release10")]
-        [InlineData("release-1.0", "{shortBRANCHNAME}", "release10")]
-        public void Resolve_Replaces_BranchName(string branchName, string input, string expected)
+        [InlineData("refs/heads/master", "{branchNameSuffix}", "master")]
+        [InlineData("refs/heads/master", "{BRANCHNAMESUFFIX}", "master")]
+        [InlineData("refs/heads/release/1.0", "{BRANCHNAMESuffix}", "10")]
+        [InlineData("refs/heads/release-1.0", "{BRANCHNAMEsuffix}", "release10")]
+        public void Resolve_Replaces_CanonicalBranchName(string branchName, string input, string expected)
         {
             // Arrange
-            var sut = new ShortBranchNameRule();
+            var sut = new BranchNameSuffixRule();
             var context = new VersionContext
             {
                 Result =
                 {
-                    BranchName = branchName
+                    CanonicalBranchName = branchName
                 }
             };
 
@@ -65,18 +65,17 @@ namespace SimpleVersion.Core.Tests.Rules
             result.Should().Be(expected);
         }
 
-      
         [Theory]
-        [InlineData("master", "{shortbranchName}", "[mr]", "aste")]
+        [InlineData("master", "{branchNameSuffix}", "[mr]", "aste")]
         public void Resolve_CustomPattern_Replaces_BranchName(string branchName, string input, string pattern, string expected)
         {
             // Arrange
-            var sut = new ShortBranchNameRule(pattern);
+            var sut = new BranchNameSuffixRule(pattern);
             var context = new VersionContext
             {
                 Result =
                 {
-                    BranchName = branchName
+                    CanonicalBranchName = branchName
                 }
             };
 


### PR DESCRIPTION
Enables a token of `{branchnamesuffix}` to be used in label/metadata.  Resolves to the last segment of the branch canonicalname