### PR TITLE
bug: Use * as part of a label string

### DIFF
--- a/src/SimpleVersion.Core/Rules/HeightRule.cs
+++ b/src/SimpleVersion.Core/Rules/HeightRule.cs
@@ -37,7 +37,7 @@ namespace SimpleVersion.Rules
         {
             if (!context.Configuration.Version.Contains(Token)
                 && input.Count() != 0
-                && !input.Contains(Token))
+                && !input.Any(x => x.Contains(Token)))
             {
                 return input.Concat(new[] { Token });
             }

--- a/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver1FormatProcessFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver1FormatProcessFixture.cs
@@ -23,6 +23,9 @@ namespace SimpleVersion.Core.Tests.Pipeline.Formatting
             yield return new object[] { new[] { "one", "two" }, "1.2.0", 106, "1.2.0-one-two-0106" };
             yield return new object[] { new[] { "*", "one", "two" }, "1.2.0", 106, "1.2.0-0106-one-two" };
             yield return new object[] { new[] { "one", "*", "two" }, "1.2.0", 106, "1.2.0-one-0106-two" };
+            yield return new object[] { new[] { "one", "two*", "three" }, "1.2.0", 106, "1.2.0-one-two0106-three" };
+            yield return new object[] { new[] { "one", "*two*", "three" }, "1.2.0", 106, "1.2.0-one-0106two0106-three" };
+            yield return new object[] { new[] { "one", "*t*o*", "three" }, "1.2.0", 106, "1.2.0-one-0106t0106o0106-three" };
         }
 
         [Theory]


### PR DESCRIPTION
# Description
Ensure `*` can be used in part of a label string.  E.g. `label: "[ '*', 'r*', '*r*']"` are now all valid uses (the same for metadata

Fixes #61

## Change Type

- [ ] Documentation: Changes to docs are included
- [ ] Infrastructure: Changes to build scripts/non-deliverables
- [x] Bug Fix: Fixes an issue in implementation
- [ ] New Feature: Adds new functionality in a non-breaking manner
- [ ] Breaking Change: Implements a fix or feature in a breaking manner

# Quality
- [x] Unit tests have been added/updated
- [x] Local builds/testing are successful
- [x] Code coverage has not decreased
- [x] Code comments have been provided (where appropriate)
- [x] Core styles have been followed
- [ ] Documentation has been added/updated
