### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Kieranties/bcfc93d7-b67e-44a7-98f2-dee50418980b/c51434c9-f07f-4026-a750-7c18ed218a1a/_apis/work/boardbadge/f470a337-99ab-4e16-9b14-73e64dda47d5)](https://dev.azure.com/Kieranties/bcfc93d7-b67e-44a7-98f2-dee50418980b/_boards/board/t/c51434c9-f07f-4026-a750-7c18ed218a1a/Microsoft.RequirementCategory)
 ![Logo]
 
 SimpleVersion


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#29](https://dev.azure.com/Kieranties/bcfc93d7-b67e-44a7-98f2-dee50418980b/_workitems/edit/29). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.