### PR TITLE
feat: Add short sha to VersionContext Result

### DIFF
--- a/docs/articles/results.md
+++ b/docs/articles/results.md
@@ -16,6 +16,7 @@ The following is an example from invoking the command line tool:
   "Height": 18,
   "HeightPadded": "0018",
   "Sha": "ebc8f22ae83bfa3c1e36d6bf70c2a383ae30c9dd",
+  "Sha7": "ebc8f22",
   "CanonicalBranchName": "refs/heads/preview/test",
   "BranchName": "preview/test",
   "Formats": {
@@ -38,6 +39,7 @@ Properties
 | Height | int | The calculated height |
 | HeightPadded | int | The calculated height padded to four digits |
 | Sha | string | The sha of the current commit at the time of invocation |
+| Sha7 | string | The sha of the current commit at the time of invocation, shortened to 7 characters |
 | BranchName | string | The checked out branch at the time of invocation |
 | CanonicalBranchName | string | The full canonical name of the checked out branch at the time of invocation |
 

--- a/src/SimpleVersion.Abstractions/Model/VersionResult.cs
+++ b/src/SimpleVersion.Abstractions/Model/VersionResult.cs
@@ -53,6 +53,11 @@ namespace SimpleVersion.Model
         public string Sha { get; set; }
 
         /// <summary>
+        /// Gets or sets the shortened (7 char) sha of the current commit.
+        /// </summary>
+        public string Sha7 { get; set; }
+
+        /// <summary>
         /// Gets or sets the friendly branch name of the current branch.
         /// </summary>
         public string BranchName { get; set; }

--- a/src/SimpleVersion.Core/Pipeline/VersionContext.cs
+++ b/src/SimpleVersion.Core/Pipeline/VersionContext.cs
@@ -36,12 +36,14 @@ namespace SimpleVersion.Pipeline
 
         private VersionResult SetIntialResult()
         {
+            var sha = Repository.Head.Tip?.Sha;
             return new VersionResult
             {
                 BranchName = Repository.Head.FriendlyName,
                 CanonicalBranchName = Repository.Head.CanonicalName,
-                Sha = Repository.Head.Tip?.Sha
-            };
+                Sha = sha,
+                Sha7 = (string.IsNullOrEmpty(sha) || sha.Length < 8) ? null : sha.Substring(0, 7)
+        };
         }
     }
 }

--- a/src/SimpleVersion.Core/Pipeline/VersionContext.cs
+++ b/src/SimpleVersion.Core/Pipeline/VersionContext.cs
@@ -42,8 +42,8 @@ namespace SimpleVersion.Pipeline
                 BranchName = Repository.Head.FriendlyName,
                 CanonicalBranchName = Repository.Head.CanonicalName,
                 Sha = sha,
-                Sha7 = (string.IsNullOrEmpty(sha) || sha.Length < 8) ? null : sha.Substring(0, 7)
-        };
+                Sha7 = (string.IsNullOrEmpty(sha) || sha.Length < 7) ? null : sha.Substring(0, 7)
+            };
         }
     }
 }

--- a/src/SimpleVersion.Core/Rules/ShortShaTokenRule.cs
+++ b/src/SimpleVersion.Core/Rules/ShortShaTokenRule.cs
@@ -27,8 +27,7 @@ namespace SimpleVersion.Rules
         /// <inheritdoc/>
         public string Resolve(IVersionContext context, string value)
         {
-            var shortSha = context.Result.Sha.Substring(0, 7);
-            return Regex.Replace(value, Regex.Escape(Token), $"c{shortSha}", RegexOptions.IgnoreCase);
+            return Regex.Replace(value, Regex.Escape(Token), $"c{context.Result.Sha7}", RegexOptions.IgnoreCase);
         }
 
         /// <inheritdoc/>

--- a/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver1FormatProcessFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver1FormatProcessFixture.cs
@@ -49,8 +49,7 @@ namespace SimpleVersion.Core.Tests.Pipeline.Formatting
                 };
                 context.Result.Version = context.Configuration.Version;
 
-                var shaSub = context.Result.Sha.Substring(0, 7);
-                var fullExpected = $"{expectedPart}-c{shaSub}";
+                var fullExpected = $"{expectedPart}-c{context.Result.Sha7}";
 
                 // Act
                 _sut.Apply(context);

--- a/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver2FormatProcessFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Pipeline/Formatting/Semver2FormatProcessFixture.cs
@@ -50,8 +50,7 @@ namespace SimpleVersion.Core.Tests.Pipeline.Formatting
                 context.Result.Version = context.Configuration.Version;
 
                 var divider = parts.Length > 0 ? '.' : '-';
-                var shaSub = context.Result.Sha.Substring(0, 7);
-                var fullExpected = $"{expectedPart}{divider}c{shaSub}";
+                var fullExpected = $"{expectedPart}{divider}c{context.Result.Sha7}";
 
                 // Act
                 _sut.Apply(context);
@@ -112,13 +111,12 @@ namespace SimpleVersion.Core.Tests.Pipeline.Formatting
                     Result = Utils.GetVersionResult(height, false)
                 };
                 context.Result.Version = context.Configuration.Version;
-                var shaSub = context.Result.Sha.Substring(0, 7);
 
                 string expected;
                 if (parts.Length > 0)
-                    expected = $"{version}-c{shaSub}+{string.Join(".", parts)}";
+                    expected = $"{version}-c{context.Result.Sha7}+{string.Join(".", parts)}";
                 else
-                    expected = $"{version}-c{shaSub}";
+                    expected = $"{version}-c{context.Result.Sha7}";
 
                 // Act
                 _sut.Apply(context);

--- a/test/SimpleVersion.Core.Tests/Pipeline/VersionContextFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Pipeline/VersionContextFixture.cs
@@ -35,6 +35,7 @@ namespace SimpleVersion.Core.Tests.Pipeline
                 sut.Result.BranchName.Should().Be(fixture.Repository.Head.FriendlyName);
                 sut.Result.CanonicalBranchName.Should().Be(fixture.Repository.Head.CanonicalName);
                 sut.Result.Sha.Should().BeNull();
+                sut.Result.Sha7.Should().BeNull();
             }
         }
 
@@ -56,6 +57,7 @@ namespace SimpleVersion.Core.Tests.Pipeline
                 sut.Result.BranchName.Should().Be(fixture.Repository.Head.FriendlyName);
                 sut.Result.CanonicalBranchName.Should().Be(fixture.Repository.Head.CanonicalName);
                 sut.Result.Sha.Should().Be(fixture.Repository.Head.Tip.Sha);
+                sut.Result.Sha7.Should().Be(fixture.Repository.Head.Tip.Sha.Substring(0, 7));
             }
         }
     }

--- a/test/SimpleVersion.Core.Tests/Rules/ShortShaTokenRuleFixture.cs
+++ b/test/SimpleVersion.Core.Tests/Rules/ShortShaTokenRuleFixture.cs
@@ -49,6 +49,26 @@ namespace SimpleVersion.Core.Tests.Rules
             }
         }
 
+        [Theory]
+        [InlineData("this-{shortsha}", "this-c4ca82d2")]
+        public void Resolve_ReplacesToken2_IfNeeded(string input, string expected)
+        {
+            // Arrange
+            using (var fixture = new EmptyRepositoryFixture())
+            {
+                var context = new VersionContext(fixture.Repository)
+                {
+                    Result = Utils.GetVersionResult(10)
+                };
+
+                // Act
+                var result = _sut.Resolve(context, input);
+
+                // Assert
+                result.Should().Be(expected);
+            }
+        }
+
         public static IEnumerable<object[]> ApplyData()
         {
             // release branch does not include sha

--- a/test/SimpleVersion.Core.Tests/Utils.cs
+++ b/test/SimpleVersion.Core.Tests/Utils.cs
@@ -44,6 +44,7 @@ namespace SimpleVersion.Core.Tests
                 BranchName = branchName,
                 CanonicalBranchName = "refs/heads/" + branchName,
                 Sha = "4ca82d2c58f48007bf16d69ebf036fc4ebfdd059",
+                Sha7 = "4ca82d2",
                 Height = height
             };
         }


### PR DESCRIPTION
# Description
Added Sha7 (instead of ShortSha - afaik thats one of the official names of it) to the Result object. 
Let me know if you'd prefer ShortSha instead.

Fixes #76

## Change Type

- [ ] Documentation: Changes to docs are included
- [ ] Infrastructure: Changes to build scripts/non-deliverables
- [ ] Bug Fix: Fixes an issue in implementation
- [x] New Feature: Adds new functionality in a non-breaking manner
- [ ] Breaking Change: Implements a fix or feature in a breaking manner

# Quality
- [x] Unit tests have been added/updated
- [x] Local builds/testing are successful
- [ ] Code coverage has not decreased
- [ ] Code comments have been provided (where appropriate)
- [ ] Core styles have been followed
- [ ] Documentation has been added/updated
