### PR TITLE
feat: Enable partial label/metadata overrides

### DIFF
--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -134,7 +134,7 @@ only the first match (if found) is used.
 }
 ```
 
-In th above example, any branch starting with _feature/_ will add the branches
+In the above example, any branch starting with _feature/_ will add the branches
 shortname as metadata to the generated version. E.g. _feature/testing_ will
 create a version of `0.2.0-alpha1.5.c903782+featuretesting` when there are five
 commits and the sha begins with _903782_
@@ -146,6 +146,23 @@ and have the height added into the metadata.
 > Overrides will allow the same commit to be built with different versions
 > depending on the current branch.
 
+#### Override Properties
+
+Override configuration has access to the following properties
+
+| Key               | Type                  | Required | Description                                                                               |
+| ----------------- | --------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `match`           | string                | true     | Branches with a canonical branch name matching this regular expression will be overridden |
+| `label`           | string array          | false    | Overrides `label` from the base configuration                                             |
+| `prefixlabel`     | string array          | false    | Prefixes the base configuration `label` with the given values                             |
+| `postfixlabel`    | string array          | false    | Postfixes the base configuration `label` with the given values                            |
+| `insertlabel`     | int/string dictionary | false    | Inserts the given values into the base `label` at the index specified                     |
+| `metadata`        | string array          | false    | Overrides `metdata` from the base configuration                                           |
+| `prefixmetadata`  | string array          | false    | Prefixes the base configuration `metadata` with the given values                          |
+| `postfixmetadata` | string array          | false    | Postfixes the base configuration `metadata` with the given values                         |
+| `insertmetadata`  | int/string dictionary | false    | Inserts the given values into the base `metadata` at the index specified                  |
+
+
 Replacement Tokens
 ------------------
 
@@ -155,9 +172,9 @@ substitution of values during invocation.  The following tokens may be used:
 
 | Name               | Token                | Where                          | Description                                                                |
 | ------------------ | -------------------- | ------------------------------ | -------------------------------------------------------------------------- |
-| Height             | `*`                  | `Version`, `Label`, `Metadata` | Inserts the calculated height                                              |
-| Branch Name        | `{branchname}`       | `Label`, `Metadata`            | Inserts the canonical branch name, stripped of non-alphanumeric characters |
-| Short Branch Name  | `{shortbranchname}`  | `Label`, `Metadata`            | Inserts the friendly branch name, stripped of non-alphanumeric characters  |
-| Branch Name Suffix | `{branchnamesuffix}` | `Label`, `Metadata`            | Inserts the last segment of the canonical name of a branch                 |
-| Short Sha          | `{shortsha}`         | `Label`, `Metadata`            | Inserts the first seven characters of the commit sha, prefixed with `c`    |
-| Pull-Request Id    | `{pr}`               | `Label`, `Metadata`            | Inserts the id of the pull-request (or 0 by default)                       |
+| Height             | `*`                  | `version`, `label`, `metadata` | Inserts the calculated height                                              |
+| Branch Name        | `{branchname}`       | `label`, `metadata`            | Inserts the canonical branch name, stripped of non-alphanumeric characters |
+| Short Branch Name  | `{shortbranchname}`  | `label`, `metadata`            | Inserts the friendly branch name, stripped of non-alphanumeric characters  |
+| Branch Name Suffix | `{branchnamesuffix}` | `label`, `metadata`            | Inserts the last segment of the canonical name of a branch                 |
+| Short Sha          | `{shortsha}`         | `label`, `metadata`            | Inserts the first seven characters of the commit sha, prefixed with `c`    |
+| Pull-Request Id    | `{pr}`               | `label`, `metadata`            | Inserts the id of the pull-request (or 0 by default)                       |

--- a/src/SimpleVersion.Abstractions/Model/BranchConfiguration.cs
+++ b/src/SimpleVersion.Abstractions/Model/BranchConfiguration.cs
@@ -17,14 +17,44 @@ namespace SimpleVersion.Model
 
 #pragma warning disable CA2227 // Collection properties should be read only
         /// <summary>
-        /// Gets or sets the label parts to use in the generated version.
+        /// Gets or sets the label parts to override in the generated version.
         /// </summary>
         public List<string> Label { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the Metadata parts to use in the generated version.
+        /// Gets or sets the label parts to insert at the start of the label in the generated version.
+        /// </summary>
+        public List<string> PrefixLabel { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the label parts to insert at the end of the label in the generated version.
+        /// </summary>
+        public List<string> PostfixLabel { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the label parts to insert at specific indexes of the label in the generated version.
+        /// </summary>
+        public Dictionary<int, string> InsertLabel { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the metadata parts to use in the generated version.
         /// </summary>
         public List<string> Metadata { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the metadata parts to insert at the start of the metadata in the generated version.
+        /// </summary>
+        public List<string> PrefixMetadata { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the metadata parts to insert at the end of the metadata in the generated version.
+        /// </summary>
+        public List<string> PostfixMetadata { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the metadata parts to insert at specific indexes of the metadata in the generated version.
+        /// </summary>
+        public Dictionary<int, string> InsertMetadata { get; set; } = null;
 #pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/test/SimpleVersion.Abstractions.Tests/Model/BranchConfigurationFixture.cs
+++ b/test/SimpleVersion.Abstractions.Tests/Model/BranchConfigurationFixture.cs
@@ -16,8 +16,14 @@ namespace SimpleVersion.Abstractions.Tests.Model
 
             // Assert
             sut.Label.Should().BeNull();
+            sut.PrefixLabel.Should().BeNull();
+            sut.PostfixLabel.Should().BeNull();
+            sut.InsertLabel.Should().BeNull();
             sut.Match.Should().BeEmpty();
             sut.Metadata.Should().BeNull();
+            sut.PrefixMetadata.Should().BeNull();
+            sut.PostfixMetadata.Should().BeNull();
+            sut.InsertMetadata.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
# Description
Enables support for partial or complete override of the 'label' and 'metadata' properties for specific branches.

Fixes #72

## Change Type

- [x] Documentation: Changes to docs are included
- [ ] Infrastructure: Changes to build scripts/non-deliverables
- [ ] Bug Fix: Fixes an issue in implementation
- [x] New Feature: Adds new functionality in a non-breaking manner
- [ ] Breaking Change: Implements a fix or feature in a breaking manner

# Quality
- [x] Unit tests have been added/updated
- [x] Local builds/testing are successful
- [ ] Code coverage has not decreased
- [x] Code comments have been provided (where appropriate)
- [x] Core styles have been followed
- [x] Documentation has been added/updated
