### PR TITLE
change LibGit2Sharp to latest preview version

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Source library packages">
-    <PackageReference Update="LibGit2Sharp" Version="0.26.*" />
+    <PackageReference Update="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Update="System.Text.Json" Version="4.7.*" />
     <PackageReference Update="NJsonSchema" Version="10.4.*" />
   </ItemGroup>

--- a/Packages.props
+++ b/Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Source library packages">
-    <PackageReference Update="LibGit2Sharp" Version="0.27.0-preview-0182" />
+    <PackageReference Update="LibGit2Sharp" Version="0.27.0-*" />
     <PackageReference Update="System.Text.Json" Version="4.7.*" />
     <PackageReference Update="NJsonSchema" Version="10.4.*" />
   </ItemGroup>

--- a/test/acceptance/Dockerfile
+++ b/test/acceptance/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-focal
 
-RUN apk add git \
+RUN apt get git \
     && git config --global user.email "simpleversion-acceptance@example.com" \
     && git config --global user.name "SV Acceptance"
 

--- a/test/acceptance/Dockerfile
+++ b/test/acceptance/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-focal
 
 RUN apk add git \
     && git config --global user.email "simpleversion-acceptance@example.com" \
@@ -6,9 +6,8 @@ RUN apk add git \
 
 ARG SIMPLEVERSION_VERSION
 COPY . /dist
-# Force copying of native lib into root of tool - don't pollute LD_LIBRARY_PATH
-RUN dotnet tool install SimpleVersion.Tool --version ${SIMPLEVERSION_VERSION} -g --add-source /dist \
-    && cp /root/.dotnet/tools/.store/simpleversion.tool/${SIMPLEVERSION_VERSION}/simpleversion.tool/${SIMPLEVERSION_VERSION}/tools/netcoreapp3.1/any/runtimes/linux-x64/native/* /root/.dotnet/tools/.store/simpleversion.tool/${SIMPLEVERSION_VERSION}/simpleversion.tool/${SIMPLEVERSION_VERSION}/tools/netcoreapp3.1/any
+
+RUN dotnet tool install SimpleVersion.Tool --version ${SIMPLEVERSION_VERSION} -g --add-source /dist
 
 ENV PATH="${PATH}:/root/.dotnet/tools"
 

--- a/test/acceptance/Dockerfile
+++ b/test/acceptance/Dockerfile
@@ -8,7 +8,7 @@ ARG SIMPLEVERSION_VERSION
 COPY . /dist
 # Force copying of native lib into root of tool - don't pollute LD_LIBRARY_PATH
 RUN dotnet tool install SimpleVersion.Tool --version ${SIMPLEVERSION_VERSION} -g --add-source /dist \
-    && cp /root/.dotnet/tools/.store/simpleversion.tool/${SIMPLEVERSION_VERSION}/simpleversion.tool/${SIMPLEVERSION_VERSION}/tools/netcoreapp3.1/any/runtimes/alpine.3.9-x64/native/* /root/.dotnet/tools/.store/simpleversion.tool/${SIMPLEVERSION_VERSION}/simpleversion.tool/${SIMPLEVERSION_VERSION}/tools/netcoreapp3.1/any
+    && cp /root/.dotnet/tools/.store/simpleversion.tool/${SIMPLEVERSION_VERSION}/simpleversion.tool/${SIMPLEVERSION_VERSION}/tools/netcoreapp3.1/any/runtimes/linux-x64/native/* /root/.dotnet/tools/.store/simpleversion.tool/${SIMPLEVERSION_VERSION}/simpleversion.tool/${SIMPLEVERSION_VERSION}/tools/netcoreapp3.1/any
 
 ENV PATH="${PATH}:/root/.dotnet/tools"
 

--- a/test/acceptance/Dockerfile
+++ b/test/acceptance/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-focal
 
-RUN apt get git \
+RUN apt install -y --no-install-recommends git \
     && git config --global user.email "simpleversion-acceptance@example.com" \
     && git config --global user.name "SV Acceptance"
 


### PR DESCRIPTION
# Description
It appears that the current stable release of LibGit2Sharp is having a dependency on openSSH 1.0 that is no longer supported on Ubuntu (From 20.04 as far as I can see) resulting in the tool breaking. updating to this preview version solves the problem.

<!--
    Provide one or more issues this PR fixes
-->
Fixes #144

## Change Type
<!-- Please update each entry that applies with '[x]' -->
- [ ] Documentation: Changes to docs are included
- [ ] Infrastructure: Changes to build scripts/non-deliverables
- [x] Bug Fix: Fixes an issue in implementation
- [ ] New Feature: Adds new functionality in a non-breaking manner
- [ ] Breaking Change: Implements a fix or feature in a breaking manner
- [ ] Other - <!-- please specify -->

# Quality Checks
<!-- Please update each entry that applies with '[x]' -->
- [ ] Unit tests have been added/updated
- [ ] Acceptance tests have been added/updated
- [x] Local builds/testing are successful
- [x] Code coverage has not decreased
- [ ] Code comments have been provided (where appropriate)
- [ ] Core styles have been followed
- [ ] Documentation has been added/updated
