### PR TITLE
feat: Support net6

### DIFF
--- a/.simpleversion.json
+++ b/.simpleversion.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://simpleversion.kieranties.com/schema/unstable.json",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "branches": {
     "release": [".+"],
     "overrides": [

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Meta">
+    <TargetFramework>net6.0</TargetFramework>
     <Version Condition="'$(Version)' == ''">1.0.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -29,10 +30,10 @@
     <None Include="logo.png" Condition="Exists('logo.png')" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)shared\logo.png" Condition="!Exists('logo.png')" Pack="true" PackagePath="\" />
   </ItemGroup>
-  
+
   <PropertyGroup Label="Build Attributes">
     <TreatWarningsAsErrors Condition="$(Configuration) == 'Release'">true</TreatWarningsAsErrors>
-    <MSBuildTreatWarningsAsErrors  Condition="$(Configuration) == 'Release'">true</MSBuildTreatWarningsAsErrors>    
+    <MSBuildTreatWarningsAsErrors  Condition="$(Configuration) == 'Release'">true</MSBuildTreatWarningsAsErrors>
     <!-- NU5105 - Usage of semver 2 versioning -->
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>

--- a/Packages.props
+++ b/Packages.props
@@ -10,19 +10,19 @@
 
   <ItemGroup Label="Source library packages">
     <PackageReference Update="LibGit2Sharp" Version="0.27.0-*" />
-    <PackageReference Update="System.Text.Json" Version="4.7.*" />
-    <PackageReference Update="NJsonSchema" Version="10.4.*" />
+    <PackageReference Update="System.Text.Json" Version="6.0.*" />
+    <PackageReference Update="NJsonSchema" Version="10.7.*" />
   </ItemGroup>
 
   <ItemGroup Label="Docs site packages">
-    <PackageReference Update="docfx.console" Version="2.57.*" PrivateAssets="All" />
+    <PackageReference Update="docfx.console" Version="2.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Label="Test library packages">
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Update="xunit" Version="$(_xunit)" />
     <PackageReference Update="xunit.runner.visualstudio" Version="$(_xunit)" />
-    <PackageReference Update="FluentAssertions" Version="5.*" />
+    <PackageReference Update="FluentAssertions" Version="6.*" />
     <PackageReference Update="GitTools.Testing" Version="1.*" />
     <PackageReference Update="NSubstitute" Version="4.*" />
     <PackageReference Update="coverlet.msbuild" Version="3.*" />
@@ -30,7 +30,6 @@
   </ItemGroup>
 
   <ItemGroup Label="Global project tooling">
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.FXCopAnalyzers" Version="2.*" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.*" />
   </ItemGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,25 +93,20 @@ jobs:
     DOCKER_BUILDKIT: 1
   strategy:
     matrix:
-      alpine-3.14:
-        tag: 3.1-alpine3.14
+      alpine-3.15:
+        tag: 6.0-alpine3.15
         os: alpine
-      # TODO: Missing assets in libgit 27 to support alpine
-      # https://github.com/Kieranties/SimpleVersion/issues/149
-      # alpine-3.15:
-      #   tag: 3.1-alpine3.15
-      #   os: alpine
+      alpine-3.16:
+        tag: 6.0-alpine3.16
+        os: alpine
+      ubuntu-22.04:
+        tag: 6.0-jammy
+        os: ubuntu
       ubuntu-20.04:
-        tag: 3.1-focal
+        tag: 6.0-focal
         os: ubuntu
-      ubuntu-18.04:
-        tag: 3.1-bionic
-        os: ubuntu
-      debian-10:
-        tag: 3.1-buster
-        os: debian
       debian-11:
-        tag: 3.1-bullseye
+        tag: 6.0-bullseye-slim
         os: debian
 
   steps:

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "6.0.300",
+    "rollForward": "latestFeature"
+  },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"
   }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., Directory.Build.props))\Directory.Build.props"/>
 
   <PropertyGroup>
+    <RootNamespace>SimpleVersion</RootNamespace>
     <Nullable>enable</Nullable>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/SimpleVersion.Abstractions/ISerializer.cs
+++ b/src/SimpleVersion.Abstractions/ISerializer.cs
@@ -21,6 +21,6 @@ namespace SimpleVersion
         /// <typeparam name="T">The type to deserialize.</typeparam>
         /// <param name="value">A string representation of <typeparamref name="T"/>.</param>
         /// <returns>An new instance of <typeparamref name="T"/> populated from <paramref name="value"/>.</returns>
-        T Deserialize<T>(string value);
+        T? Deserialize<T>(string value);
     }
 }

--- a/src/SimpleVersion.Abstractions/SimpleVersion.Abstractions.csproj
+++ b/src/SimpleVersion.Abstractions/SimpleVersion.Abstractions.csproj
@@ -1,7 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RootNamespace>SimpleVersion</RootNamespace>
-  </PropertyGroup>
 </Project>

--- a/src/SimpleVersion.Core/Comparers/VersionConfigurationLabelComparer.cs
+++ b/src/SimpleVersion.Core/Comparers/VersionConfigurationLabelComparer.cs
@@ -18,7 +18,7 @@ namespace SimpleVersion.Comparers
         /// <param name="x">The first <see cref="VersionConfiguration"/> to compare.</param>
         /// <param name="y">The second <see cref="VersionConfiguration"/> to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
-        public bool Equals(VersionConfiguration x, VersionConfiguration y)
+        public bool Equals(VersionConfiguration? x, VersionConfiguration? y)
         {
             if (ReferenceEquals(x, y))
             {

--- a/src/SimpleVersion.Core/Environment/EnvironmentVariableAccessor.cs
+++ b/src/SimpleVersion.Core/Environment/EnvironmentVariableAccessor.cs
@@ -9,6 +9,6 @@ namespace SimpleVersion.Environment
     public class EnvironmentVariableAccessor : IEnvironmentVariableAccessor
     {
         /// <inheritdoc/>
-        public string GetVariable(string name) => System.Environment.GetEnvironmentVariable(name);
+        public string? GetVariable(string name) => System.Environment.GetEnvironmentVariable(name);
     }
 }

--- a/src/SimpleVersion.Core/GitVersionRepository.cs
+++ b/src/SimpleVersion.Core/GitVersionRepository.cs
@@ -54,6 +54,7 @@ namespace SimpleVersion
             // Fetch repository configuration
             var repoConfig = GetRespositoryConfiguration();
             var canonicalBranchName = _environment.CanonicalBranchName ?? _repo.Head.CanonicalName;
+            var repoPath = Directory.GetParent(_repo.Info.Path)?.Parent ?? throw new DirectoryNotFoundException($"Repository path could not be resolved: {_repo.Info.Path}");
 
             // Compose base result data
             var result = new VersionResult
@@ -63,7 +64,7 @@ namespace SimpleVersion
                 Sha = _repo.Head.Tip.Sha,
 
                 // Value returned from repository has trailing slash so need to get parent twice.
-                RepositoryPath = Directory.GetParent(_repo.Info.Path).Parent.FullName,
+                RepositoryPath = repoPath.FullName,
                 IsRelease = repoConfig.Branches.Release.Any(x => Regex.IsMatch(canonicalBranchName, x))
             };
 

--- a/src/SimpleVersion.Core/Serialization/Converters/DictionaryConverter.cs
+++ b/src/SimpleVersion.Core/Serialization/Converters/DictionaryConverter.cs
@@ -41,7 +41,10 @@ namespace SimpleVersion.Serialization.Converters
             }
 
             var converterType = typeof(DictionaryConverter<,>).MakeGenericType(typeToConvert.GetGenericArguments());
-            return (JsonConverter)Activator.CreateInstance(converterType);
+            var instance = Activator.CreateInstance(converterType);
+            return instance == null
+                ? throw new InvalidOperationException($"Could not create an instance of type {converterType}.")
+                : (instance as JsonConverter) !;
         }
     }
 }

--- a/src/SimpleVersion.Core/Serialization/Serializer.cs
+++ b/src/SimpleVersion.Core/Serialization/Serializer.cs
@@ -27,7 +27,7 @@ namespace SimpleVersion.Serialization
         };
 
         /// <inheritdoc />
-        public T Deserialize<T>(string value) => JsonSerializer.Deserialize<T>(value, _options);
+        public T? Deserialize<T>(string value) => JsonSerializer.Deserialize<T>(value, _options);
 
         /// <inheritdoc />
         public string Serialize(object value) => JsonSerializer.Serialize(value, _options);

--- a/src/SimpleVersion.Core/SimpleVersion.Core.csproj
+++ b/src/SimpleVersion.Core/SimpleVersion.Core.csproj
@@ -1,10 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RootNamespace>SimpleVersion</RootNamespace>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" PrivateAssets="None" />
     <PackageReference Include="System.Text.Json" />

--- a/src/SimpleVersion.Docs/SchemaGenerator.cs
+++ b/src/SimpleVersion.Docs/SchemaGenerator.cs
@@ -35,7 +35,8 @@ namespace SimpleVersion.Docs
 
             var schema = JsonSchema.FromType(type, settings);
             schema.Properties.Add("$schema", new JsonSchemaProperty { Type = JsonObjectType.String });
-            Directory.CreateDirectory(Directory.GetParent(path).FullName);
+            var targetPath = Directory.GetParent(path) ?? throw new DirectoryNotFoundException($"Target path could not be resolved: {path}");
+            Directory.CreateDirectory(targetPath.FullName);
             File.WriteAllText(path, schema.ToJson());
         }
     }

--- a/src/SimpleVersion.Docs/SimpleVersion.Docs.csproj
+++ b/src/SimpleVersion.Docs/SimpleVersion.Docs.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
@@ -30,7 +29,7 @@
       <FileName>latest</FileName>
       <FileName Condition="$(Version.Contains('-'))">unstable</FileName>
     </PropertyGroup>
-    
+
     <Exec Command="dotnet $(OutputPath)/$(AssemblyName).dll $(MSBuildThisFileDirectory)site/schema/$(FileName).json" />
   </Target>
 

--- a/src/SimpleVersion.Tool/SimpleVersion.Tool.csproj
+++ b/src/SimpleVersion.Tool/SimpleVersion.Tool.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>simpleversion</ToolCommandName>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., Directory.Build.props))\Directory.Build.props"/>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Documentation for tests is not needed-->
     <NoWarn>$(NoWarn);SA0001</NoWarn>
@@ -18,7 +17,7 @@
   <ItemGroup Label="Coverage">
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/test/acceptance/Dockerfile
+++ b/test/acceptance/Dockerfile
@@ -1,5 +1,5 @@
 ARG OS=alpine
-ARG TAG=3.1-alpine3.14
+ARG TAG=6.0-alpine3.15
 ARG IMAGE=mcr.microsoft.com/dotnet/sdk
 
 FROM ${IMAGE}:${TAG} as alpine


### PR DESCRIPTION
# Description
Update application target to net6 now that 3.1 is reaching end of line.
Minor clean up of csproj files and updates to acceptance test targets to match latest net6 images from Microsoft

BREAKING: 3.1 support is dropped entirely

Fixes #150
Closes #147 
Closes #140
Closes #138
Closes #137
Closes #136 
Closes #125
Closes #124


## Change Type
<!-- Please update each entry that applies with '[x]' -->
- [ ] Documentation: Changes to docs are included
- [x] Infrastructure: Changes to build scripts/non-deliverables
- [ ] Bug Fix: Fixes an issue in implementation
- [ ] New Feature: Adds new functionality in a non-breaking manner
- [x] Breaking Change: Implements a fix or feature in a breaking manner
- [ ] Other - <!-- please specify -->

# Quality Checks
<!-- Please update each entry that applies with '[x]' -->
- [ ] Unit tests have been added/updated
- [x] Acceptance tests have been added/updated
- [x] Local builds/testing are successful
- [x] Code coverage has not decreased
- [ ] Code comments have been provided (where appropriate)
- [x] Core styles have been followed
- [ ] Documentation has been added/updated
